### PR TITLE
fix: query user subscriptions with default permissions

### DIFF
--- a/saleor/graphql/subscription/resolvers.py
+++ b/saleor/graphql/subscription/resolvers.py
@@ -1,6 +1,6 @@
 import graphene
+import graphene_django_optimizer as gql_optimizer
 
-# from ...subscription.events import SubscriptionEvents
 from .types import Subscription
 from ...subscription import SubscriptionStatus, models
 
@@ -8,8 +8,8 @@ SUBSCRIPTION_SEARCH_FIELDS = ("id", "token")
 
 
 def resolve_subscriptions(info, **_kwargs):
-    return models.Subscription.objects.confirmed()
-
+    queryset = models.Subscription.objects.filter(user=info.context.user.id)
+    return gql_optimizer.query(queryset, info)
 
 def resolve_draft_subscriptions(info, **_kwargs):
     return models.Subscription.objects.confirmed().filter(

--- a/saleor/graphql/subscription/schema.py
+++ b/saleor/graphql/subscription/schema.py
@@ -9,8 +9,6 @@ from .resolvers import resolve_subscription, resolve_subscriptions, \
     resolve_subscription_by_token, resolve_draft_subscriptions
 from .types import Subscription
 from ..core.fields import FilterInputConnectionField
-from ..decorators import permission_required
-from ...core.permissions import SubscriptionPermissions
 
 
 class SubscriptionQueries(graphene.ObjectType):
@@ -39,15 +37,12 @@ class SubscriptionQueries(graphene.ObjectType):
         ),
     )
 
-    @permission_required(SubscriptionPermissions.MANAGE_SUBSCRIPTIONS)
     def resolve_subscription(self, info, **data):
         return resolve_subscription(info, data.get("id"))
 
-    @permission_required(SubscriptionPermissions.MANAGE_SUBSCRIPTIONS)
     def resolve_subscriptions(self, info, **_kwargs):
         return resolve_subscriptions(info)
 
-    @permission_required(SubscriptionPermissions.MANAGE_SUBSCRIPTIONS)
     def resolve_draft_subscriptions(self, info, **_kwargs):
         return resolve_draft_subscriptions(info)
 


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
